### PR TITLE
Only utilize public methods when interacting with URI

### DIFF
--- a/lib/Catalyst/Plugin/VersionedURI.pm
+++ b/lib/Catalyst/Plugin/VersionedURI.pm
@@ -199,15 +199,14 @@ around uri_for => sub {
     my $uris_re = $self->versioned_uri_regex
         or return $uri;
 
-    my $base = $self->req->base;
-    $base =~ s#(?<!/)$#/#;  # add trailing '/'
-
-    return $uri unless $$uri =~  m#(^\Q$base\E$uris_re)#;
+    return $uri unless $uri->path =~ m#^/($uris_re)#;
 
     my $version = $self->uri_version( $uri, @args );
 
     if ( state $in_path = $self->config->{'Plugin::VersionedURI'}{in_path} ) {
-        $$uri =~ s#(^\Q$base\E$uris_re)#${1}v$version/#;
+        my $path = $uri->path;
+        $path =~ s#^/($uris_re)#${1}v$version/#;
+        $uri->path( $path );
     } 
     else {
         state $version_name = $self->config->{'Plugin::VersionedURI'}{param} || 'v';


### PR DESCRIPTION
This changes the around 'uri_for' code to only interact with the URI
(which is returned by the original method) through public methods. This
allows the user to use other plugins that interact with URI (ie,
Catalyst::Plugin::SmartURI).
